### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,19 +30,14 @@ To use this module for the ACME DNS challenge, [configure the ACME issuer in you
 or with the Caddyfile:
 
 ```
-# globally
-{
-	acme_dns civo {
-	    api_token      = "{env.CIVO_TOKEN}"
+tls {
+	dns civo {
+		api_token {env.CIVO_TOKEN}
 	}
 }
 ```
 
-```
-# one site
-tls {
-	dns civo {
-	    api_token      = "{env.CIVO_TOKEN}"
-	}
-}
-```
+
+## Authenticating
+
+See [the associated README in the libdns package](https://github.com/libdns/civo) for important information about credentials.


### PR DESCRIPTION
- Tabs instead of spaces
- Remove redundant Caddyfile global example
- Caddyfile syntax doesn't use `=`, and the quotes aren't necessary
- Added a link to the libdns plugin - typically people will land on this repo, and we should give them a quick link to jump to the libdns plugin which should actually contain information about how to set up authentication